### PR TITLE
fix(sitemap): use /contacts (not /contact)

### DIFF
--- a/src/app/sitemap/pages/sitemap.ts
+++ b/src/app/sitemap/pages/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
 
-const pages = ["/", "/about", "/blog", "/contact", "/minecraft", "/pix"];
+const pages = ["/", "/about", "/blog", "/contacts", "/minecraft", "/pix"];
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const urlDomain = process.env.NEXT_DOMAIN || "http://localhost:3000";

--- a/src/app/sitemap/projects/sitemap.ts
+++ b/src/app/sitemap/projects/sitemap.ts
@@ -1,7 +1,7 @@
 import { getAllProjectsIds } from "@/services/firebase/adminForEdge/projects";
 import type { MetadataRoute } from "next";
 
-const pages = ["/", "/about", "/blog", "/contact", "/minecraft", "/pix"];
+const pages = ["/", "/about", "/blog", "/contacts", "/minecraft", "/pix"];
 const otherSitemaps = ["/blog-posts/sitemap.xml"];
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {

--- a/src/app/sitemap/projects/sitemap.ts
+++ b/src/app/sitemap/projects/sitemap.ts
@@ -1,8 +1,6 @@
 import { getAllProjectsIds } from "@/services/firebase/adminForEdge/projects";
 import type { MetadataRoute } from "next";
 
-const pages = ["/", "/about", "/blog", "/contacts", "/minecraft", "/pix"];
-const otherSitemaps = ["/blog-posts/sitemap.xml"];
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const urlDomain = process.env.NEXT_DOMAIN || "http://localhost:3000";


### PR DESCRIPTION
Corrige o sitemap de páginas para listar a URL correta da rota de Contatos.

Evidência local (conteúdo):
- /contacts renderiza com canonical=https://www.gui.dev.br/contacts
- /contact retorna 404 na plataforma (apesar de redirecionamentos existentes na raiz).

Arquivos alterados:
- src/app/sitemap/pages/sitemap.ts
- src/app/sitemap/projects/sitemap.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the contact page URL in site sitemaps from "/contact" to "/contacts" to ensure proper routing and search engine visibility.

* **Chores**
  * Minor sitemap cleanup and simplification for project entries while preserving existing sitemap behavior and metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsbenevides2/website/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->