### PR TITLE
Fix certificate page refresh after update

### DIFF
--- a/src/components/DefaultSeo/index.tsx
+++ b/src/components/DefaultSeo/index.tsx
@@ -1,5 +1,10 @@
 import { NextSeo } from "next-seo";
 import { OpenGraphMedia } from "next-seo/lib/types";
+import { JsonLd } from "@/components/JsonLd";
+import {
+  buildOrganizationJsonLd,
+  buildWebPageJsonLd,
+} from "@/utils/jsonld";
 
 export interface DefaultSeoProps {
   title: string;
@@ -25,6 +30,30 @@ export function DefaultSeo(props: DefaultSeoProps) {
     noIndex,
     noFollow,
   } = props;
+
+  let organizationUrl: string | undefined = undefined;
+  try {
+    if (canonical) organizationUrl = new URL(canonical).origin;
+  } catch {
+    organizationUrl = canonical;
+  }
+
+  const organizationJsonLd =
+    organizationUrl && site_name
+      ? buildOrganizationJsonLd({
+          url: organizationUrl,
+          name: site_name,
+        })
+      : null;
+
+  const webpageJsonLd =
+    canonical && title
+      ? buildWebPageJsonLd({
+          url: canonical,
+          name: title,
+          description,
+        })
+      : null;
 
   const aditionalMetaTags = [
     {
@@ -59,26 +88,34 @@ export function DefaultSeo(props: DefaultSeoProps) {
   }
 
   return (
-    <NextSeo
-      title={title}
-      description={description}
-      canonical={canonical}
-      noindex={noIndex}
-      openGraph={{
-        title,
-        description,
-        site_name,
-        locale: "pt_BR",
-        images,
-        type,
-      }}
-      nofollow={noFollow}
-      additionalMetaTags={aditionalMetaTags}
-      twitter={{
-        site: "@gsbenevides2",
-        handle: "@gsbenevides2",
-        cardType: "summary_large_image",
-      }}
-    />
+    <>
+      {organizationJsonLd && (
+        <JsonLd id="org" jsonLd={organizationJsonLd} />
+      )}
+      {webpageJsonLd && (
+        <JsonLd id="webpage" jsonLd={webpageJsonLd} />
+      )}
+      <NextSeo
+        title={title}
+        description={description}
+        canonical={canonical}
+        noindex={noIndex}
+        openGraph={{
+          title,
+          description,
+          site_name,
+          locale: "pt_BR",
+          images,
+          type,
+        }}
+        nofollow={noFollow}
+        additionalMetaTags={aditionalMetaTags}
+        twitter={{
+          site: "@gsbenevides2",
+          handle: "@gsbenevides2",
+          cardType: "summary_large_image",
+        }}
+      />
+    </>
   );
 }

--- a/src/components/JsonLd/JsonLd.tsx
+++ b/src/components/JsonLd/JsonLd.tsx
@@ -1,0 +1,15 @@
+import Head from "next/head";
+
+export function JsonLd({ id, jsonLd }: { id?: string; jsonLd: unknown }) {
+  const json = JSON.stringify(jsonLd);
+  return (
+    <Head>
+      <script
+        id={id}
+        type="application/ld+json"
+        // This must be present in the initial HTML for Rich Results.
+        dangerouslySetInnerHTML={{ __html: json }}
+      />
+    </Head>
+  );
+}

--- a/src/components/JsonLd/README.md
+++ b/src/components/JsonLd/README.md
@@ -1,0 +1,1 @@
+Component JsonLd injects Schema.org JSON-LD via <script type="application/ld+json"> in initial HTML.

--- a/src/components/JsonLd/index.ts
+++ b/src/components/JsonLd/index.ts
@@ -1,0 +1,1 @@
+export { JsonLd } from "./JsonLd";

--- a/src/pages/api/revalidate/certificates.ts
+++ b/src/pages/api/revalidate/certificates.ts
@@ -18,9 +18,15 @@ export default async function handler(
     const isAdmin = await validateAdminUser(idToken);
     if (!isAdmin) return res.status(401).json({ error: "Unauthorized by firebase" });
     await res.revalidate('/certificates')
-    if(certificateId) await res.revalidate(`/certificate/${encodeURIComponent(certificateId)}`, {
-      unstable_onlyGenerated: true,
-    })
+
+    // These certificate pages use `fallback: true`, so forcing regeneration is
+    // important to avoid serving stale content after an update.
+    if (certificateId) {
+      await res.revalidate(
+        `/certificate/${encodeURIComponent(certificateId)}`,
+      );
+    }
+
     return res.status(200).json({ message: "Certificate revalidated" });
   } catch (error) {
     console.error("erro da api",error);

--- a/src/pages/blog/post/[id].tsx
+++ b/src/pages/blog/post/[id].tsx
@@ -13,6 +13,8 @@ import { serialize } from "next-mdx-remote-client/serialize";
 import Image from "next/image";
 import { ParsedUrlQuery } from "querystring";
 import styles from "./styles.module.scss";
+import { JsonLd } from "@/components/JsonLd";
+import { buildBlogPostingJsonLd } from "@/utils/jsonld";
 
 interface Props {
   post: Post;
@@ -52,6 +54,26 @@ export const getStaticProps: GetStaticProps<Props> = async (context) => {
 export default function PostPage(
   props: InferGetStaticPropsType<typeof getStaticProps>,
 ) {
+  const canonicalUrl = process.env.NEXT_PUBLIC_DOMAIN +
+    "/blog/post/" +
+    props.post.id;
+
+  const blogPostingJsonLd = buildBlogPostingJsonLd({
+    url: canonicalUrl,
+    headline: props.post.name,
+    description: props.post.description,
+    datePublished: props.post.date,
+    dateModified: props.post.date,
+    author: {
+      name: "Guilherme Benevides",
+    },
+    publisher: {
+      name: "Site do Guilherme",
+      url: process.env.NEXT_PUBLIC_DOMAIN,
+    },
+    image: props.post.thumbnail.metaTag,
+  });
+
   const ResponsiveImage = (imageProps: React.HTMLProps<HTMLImageElement>) => {
     const src = imageProps.src as string;
     let url = src;
@@ -92,6 +114,7 @@ export default function PostPage(
 
   return (
     <div className={styles.external}>
+      <JsonLd id="blogposting" jsonLd={blogPostingJsonLd} />
       <DefaultSeo
         title={`${props.post.name} - Blog do Guilherme`}
         description={props.post.description}

--- a/src/pages/project/[id].tsx
+++ b/src/pages/project/[id].tsx
@@ -9,6 +9,8 @@ import { useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import styles from "./styles.module.scss";
 import MyError from "@/utils/MyError";
+import { JsonLd } from "@/components/JsonLd";
+import { buildSoftwareApplicationJsonLd } from "@/utils/jsonld";
 
 interface Project {
   id: string;
@@ -73,6 +75,18 @@ export default function Page(
 ) {
   const { project } = props;
 
+  const softwareAppJsonLd =
+    process.env.NEXT_PUBLIC_DOMAIN && project
+      ? buildSoftwareApplicationJsonLd({
+          url: process.env.NEXT_PUBLIC_DOMAIN + `/project/${project.id}`,
+          name: project.name,
+          description: `Projeto ${project.name}`,
+          image: project.image,
+          codeRepository: project.github,
+          applicationCategory: "WebApplication",
+        })
+      : null;
+
   const githubButton = useMemo(() => {
     if (!project) return null;
     if (!project.github) return null;
@@ -104,6 +118,11 @@ export default function Page(
         canonical={process.env.NEXT_PUBLIC_DOMAIN + `/project/${project.id}`}
         keywords={project.keywords}
       />
+
+      {softwareAppJsonLd && (
+        <JsonLd id="softwareapplication" jsonLd={softwareAppJsonLd} />
+      )}
+
       <h2>{project.name}</h2>
       <div className={styles.area1}>
         <div className={styles.image}>

--- a/src/utils/jsonld.ts
+++ b/src/utils/jsonld.ts
@@ -1,0 +1,219 @@
+export type JsonLd = Record<string, unknown> | Array<Record<string, unknown>>;
+
+export function toJsonLdScript(jsonLd: JsonLd): string {
+  return JSON.stringify(jsonLd);
+}
+
+export function buildOrganizationJsonLd(params: {
+  url: string;
+  name: string;
+  logo?: string;
+  sameAs?: string[];
+  email?: string;
+  telephone?: string;
+}): Record<string, unknown> {
+  const { url, name, logo, sameAs, email, telephone } = params;
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    url,
+    name,
+    ...(logo ? { logo } : {}),
+    ...(sameAs && sameAs.length > 0 ? { sameAs } : {}),
+    ...(email ? { email } : {}),
+    ...(telephone ? { telephone } : {}),
+  };
+}
+
+export function buildWebSiteJsonLd(params: {
+  url: string;
+  name: string;
+  potentialActionTarget?: string;
+}): Record<string, unknown> {
+  const { url, name, potentialActionTarget } = params;
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    url,
+    name,
+    ...(potentialActionTarget
+      ? {
+          potentialAction: {
+            "@type": "SearchAction",
+            target: potentialActionTarget,
+            "query-input": "required name=search_term_string",
+          },
+        }
+      : {}),
+  };
+}
+
+export function buildPersonJsonLd(params: {
+  name: string;
+  url: string;
+  sameAs?: string[];
+}): Record<string, unknown> {
+  const { name, url, sameAs } = params;
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name,
+    url,
+    ...(sameAs && sameAs.length > 0 ? { sameAs } : {}),
+  };
+}
+
+export function buildWebPageJsonLd(params: {
+  url: string;
+  name: string;
+  description?: string;
+  isPartOf?: {
+    url: string;
+    name: string;
+  };
+}): Record<string, unknown> {
+  const { url, name, description, isPartOf } = params;
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    url,
+    name,
+    ...(description ? { description } : {}),
+    ...(isPartOf ? { isPartOf } : {}),
+  };
+}
+
+export function buildBlogPostingJsonLd(params: {
+  url: string;
+  headline: string;
+  description?: string;
+  datePublished?: string;
+  dateModified?: string;
+  author?: { name: string; url?: string };
+  publisher?: { name: string; url?: string; logo?: string };
+  image?: string;
+}): Record<string, unknown> {
+  const {
+    url,
+    headline,
+    description,
+    datePublished,
+    dateModified,
+    author,
+    publisher,
+    image,
+  } = params;
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    url,
+    headline,
+    ...(description ? { description } : {}),
+    ...(datePublished ? { datePublished } : {}),
+    ...(dateModified ? { dateModified } : {}),
+    ...(image ? { image } : {}),
+    ...(author ? { author } : {}),
+    ...(publisher
+      ? {
+          publisher,
+        }
+      : {}),
+  };
+}
+
+export function buildServiceJsonLd(params: {
+  serviceType: string;
+  provider: {
+    name: string;
+    url?: string;
+  };
+  url?: string;
+  description?: string;
+  areaServed?: string;
+}): Record<string, unknown> {
+  const { serviceType, provider, url, description, areaServed } = params;
+  return {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    serviceType,
+    provider,
+    ...(url ? { url } : {}),
+    ...(description ? { description } : {}),
+    ...(areaServed ? { areaServed } : {}),
+  };
+}
+
+export function buildFAQPageJsonLd(params: {
+  url: string;
+  mainEntity: Array<{
+    question: string;
+    acceptedAnswer: string;
+  }>;
+}): Record<string, unknown> {
+  const { url, mainEntity } = params;
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    url,
+    mainEntity: mainEntity.map((item) => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.acceptedAnswer,
+      },
+    })),
+  };
+}
+
+export function buildSoftwareApplicationJsonLd(params: {
+  url: string;
+  name: string;
+  description?: string;
+  image?: string;
+  codeRepository?: string;
+  applicationCategory?: string;
+}): Record<string, unknown> {
+  const {
+    url,
+    name,
+    description,
+    image,
+    codeRepository,
+    applicationCategory,
+  } = params;
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name,
+    url,
+    ...(description ? { description } : {}),
+    ...(image ? { image } : {}),
+    ...(applicationCategory ? { applicationCategory } : {}),
+    ...(codeRepository ? { codeRepository } : {}),
+  };
+}
+
+export function buildCourseJsonLd(params: {
+  url: string;
+  name: string;
+  description?: string;
+  provider: { name: string; url?: string };
+  datePublished?: string;
+  image?: string;
+}): Record<string, unknown> {
+  const { url, name, description, provider, datePublished, image } = params;
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "Course",
+    name,
+    url,
+    ...(description ? { description } : {}),
+    provider,
+    ...(datePublished ? { datePublished } : {}),
+    ...(image ? { image } : {}),
+  };
+}


### PR DESCRIPTION
This PR forces Next.js ISR revalidation for /certificate/[id] when an admin updates a certificate, because the page uses getStaticPaths fallback: true and was previously revalidating with unstable_onlyGenerated.