### PR TITLE
Fix revalidate for fallback:true dynamic routes

### DIFF
--- a/src/pages/api/revalidate/blog.ts
+++ b/src/pages/api/revalidate/blog.ts
@@ -16,10 +16,14 @@ export default async function handler(
     if (!postId) return res.status(400).json({ error: "Missing postId" });
     const isAdmin = await validateAdminUser(idToken);
     if (!isAdmin) return res.status(401).json({ error: "Unauthorized" });
-    await res.revalidate('/blog')
-    await res.revalidate(`/blog/post/${encodeURIComponent(postId)}`, {
-      unstable_onlyGenerated: true,
-    })
+
+    await res.revalidate("/blog");
+
+    // /blog/post/[id] uses `fallback: "blocking"`, so we need to force
+    // regeneration (not `unstable_onlyGenerated`) to avoid serving stale
+    // content after updates.
+    await res.revalidate(`/blog/post/${encodeURIComponent(postId)}`);
+
     return res.status(200).json({ message: "Post revalidated" });
   } catch (error) {
     console.error(error);

--- a/src/pages/api/revalidate/certificates.ts
+++ b/src/pages/api/revalidate/certificates.ts
@@ -18,9 +18,12 @@ export default async function handler(
     const isAdmin = await validateAdminUser(idToken);
     if (!isAdmin) return res.status(401).json({ error: "Unauthorized by firebase" });
     await res.revalidate('/certificates')
-    if(certificateId) await res.revalidate(`/certificate/${encodeURIComponent(certificateId)}`, {
-      unstable_onlyGenerated: true,
-    })
+
+    // /certificate/[id] uses `fallback: true`, so we need to force regeneration
+    // (not `unstable_onlyGenerated`) to avoid serving stale content after updates.
+    if (certificateId)
+      await res.revalidate(`/certificate/${encodeURIComponent(certificateId)}`);
+
     return res.status(200).json({ message: "Certificate revalidated" });
   } catch (error) {
     console.error("erro da api",error);

--- a/src/pages/api/revalidate/cms.ts
+++ b/src/pages/api/revalidate/cms.ts
@@ -17,9 +17,13 @@ export default async function handler(
     //if (!certificateId) return res.status(400).json({ error: "Missing certificateId" });
     const isAdmin = await validateAdminUser(idToken);
     if (!isAdmin) return res.status(401).json({ error: "Unauthorized by firebase" });
-    if(pageUrl) await res.revalidate(pageUrl, {
-      unstable_onlyGenerated: true,
-    })
+
+    if (pageUrl) {
+      // CMS pages might be served via ISR/ISG; force regeneration instead of
+      // relying on `unstable_onlyGenerated`.
+      await res.revalidate(pageUrl);
+    }
+
     return res.status(200).json({ message: "Page revalidated" });
   } catch (error) {
     console.error("erro da api",error);

--- a/src/pages/api/revalidate/projects.ts
+++ b/src/pages/api/revalidate/projects.ts
@@ -17,9 +17,7 @@ export default async function handler(
     const isAdmin = await validateAdminUser(idToken);
     if (!isAdmin) return res.status(401).json({ error: "Unauthorized" });
     await res.revalidate('/projects')
-    await res.revalidate(`/project/${encodeURIComponent(projectId)}`, {
-      unstable_onlyGenerated: true,
-    })
+    await res.revalidate(`/project/${encodeURIComponent(projectId)}`);
     return res.status(200).json({ message: "Project revalidated" });
   } catch (error) {
     console.error(error);

--- a/src/pages/api/revalidate/projects.ts
+++ b/src/pages/api/revalidate/projects.ts
@@ -16,8 +16,13 @@ export default async function handler(
     if (!projectId) return res.status(400).json({ error: "Missing projectId" });
     const isAdmin = await validateAdminUser(idToken);
     if (!isAdmin) return res.status(401).json({ error: "Unauthorized" });
-    await res.revalidate('/projects')
+
+    await res.revalidate("/projects");
+
+    // /project/[id] uses `fallback: true`, so we need to force regeneration
+    // (not `unstable_onlyGenerated`) to avoid serving stale content after updates.
     await res.revalidate(`/project/${encodeURIComponent(projectId)}`);
+
     return res.status(200).json({ message: "Project revalidated" });
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
Adjust res.revalidate calls for dynamic routes using  to avoid serving stale content after updates.

Changes:
- src/pages/api/revalidate/projects.ts: remove unstable_onlyGenerated and force regeneration for /project/[id].

Background:
- Next.js pages with  need full revalidation (not onlyGenerated) to ensure updated data is rendered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project data refresh mechanism to ensure up-to-date information is displayed consistently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsbenevides2/website/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->